### PR TITLE
Import ip addresses over a temp table

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -15,6 +15,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new AppBundle\AppBundle(),
             new Subugoe\FindBundle\SubugoeFindBundle(),
             new Nelmio\SolariumBundle\NelmioSolariumBundle(),

--- a/app/DoctrineMigrations/Version20161025101318.php
+++ b/app/DoctrineMigrations/Version20161025101318.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20161025101318 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('CREATE TEMPORARY TABLE __temp__user AS SELECT id, startIpAddress, endIpAddress, institution, product FROM user');
+        $this->addSql('DROP TABLE user');
+        $this->addSql('CREATE TABLE user (id INTEGER NOT NULL, startIpAddress INTEGER NOT NULL, endIpAddress INTEGER NOT NULL, institution VARCHAR(255) DEFAULT NULL COLLATE BINARY, product VARCHAR(30) NOT NULL COLLATE BINARY, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO user (id, startIpAddress, endIpAddress, institution, product) SELECT id, startIpAddress, endIpAddress, institution, product FROM __temp__user');
+        $this->addSql('DROP TABLE __temp__user');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('CREATE TEMPORARY TABLE __temp__user AS SELECT id, startIpAddress, endIpAddress, institution, product FROM user');
+        $this->addSql('DROP TABLE user');
+        $this->addSql('CREATE TABLE user (id INTEGER NOT NULL, startIpAddress VARCHAR(255) NOT NULL COLLATE BINARY, endIpAddress VARCHAR(255) NOT NULL COLLATE BINARY, institution VARCHAR(255) DEFAULT NULL, product VARCHAR(30) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO user (id, startIpAddress, endIpAddress, institution, product) SELECT id, startIpAddress, endIpAddress, institution, product FROM __temp__user');
+        $this->addSql('DROP TABLE __temp__user');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",
         "league/csv": "^8.1",
-        "eightpoints/guzzle-bundle": "^5.0"
+        "eightpoints/guzzle-bundle": "^5.0",
+        "doctrine/doctrine-migrations-bundle": "^1.2"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "172dcb020fd7db7168408b61335c0213",
-    "content-hash": "2a12d4277380acf225c71aea16969d55",
+    "hash": "5b6d4424410e28920d852c787ff2d69e",
+    "content-hash": "abf819b5ddef5af686290d7e4454ecc0",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -525,6 +525,67 @@
             "time": "2016-01-26 17:28:51"
         },
         {
+            "name": "doctrine/doctrine-migrations-bundle",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
+                "reference": "0b89ee55bceb53c60bc4ba32924ac5053e377abb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/0b89ee55bceb53c60bc4ba32924ac5053e377abb",
+                "reference": "0b89ee55bceb53c60bc4ba32924ac5053e377abb",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "~1.0",
+                "doctrine/migrations": "^1.1",
+                "php": ">=5.4.0",
+                "symfony/framework-bundle": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\MigrationsBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DoctrineMigrationsBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "dbal",
+                "migrations",
+                "schema"
+            ],
+            "time": "2016-06-30 19:26:35"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.1.0",
             "source": {
@@ -698,6 +759,79 @@
                 "parser"
             ],
             "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "0d0ff5da10c5d30846da32060bd9e357abf70a05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/0d0ff5da10c5d30846da32060bd9e357abf70a05",
+                "reference": "0d0ff5da10c5d30846da32060bd9e357abf70a05",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.2",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "php": "^5.5|^7.0",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/yaml": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "dev-master",
+                "doctrine/orm": "2.*",
+                "jdorn/sql-formatter": "~1.1",
+                "johnkary/phpunit-speedtrap": "~1.0@dev",
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "~4.7",
+                "satooshi/php-coveralls": "0.6.*"
+            },
+            "suggest": {
+                "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\Migrations\\": "lib/Doctrine/DBAL/Migrations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "Database Schema migrations using Doctrine DBAL",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "migrations"
+            ],
+            "time": "2016-03-14 12:29:11"
         },
         {
             "name": "doctrine/orm",
@@ -1848,6 +1982,117 @@
             "description": "A Twig extension for succinctly traversing nested lists (e.g. navigation menus).",
             "homepage": "https://github.com/ninsuo/jordan-tree",
             "time": "2016-05-13 19:22:27"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "4b2bfc8128db95b533303942b0d5b332bffa07c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4b2bfc8128db95b533303942b0d5b332bffa07c6",
+                "reference": "4b2bfc8128db95b533303942b0d5b332bffa07c6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "~7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.2.0",
+                "phpunit/phpunit": "^5.4.7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2016-07-25 07:13:56"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "51c7fdd99dba53808aaab21b34f7a55b302c160c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/51c7fdd99dba53808aaab21b34f7a55b302c160c",
+                "reference": "51c7fdd99dba53808aaab21b34f7a55b302c160c",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.0",
+                "php": "7.0.0 - 7.0.5 || ^7.0.7",
+                "zendframework/zend-code": "3.0.0 - 3.0.2 || ^3.0.4"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.4.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^5.3.4",
+                "squizlabs/php_codesniffer": "^2.6.0"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2016-07-01 12:11:54"
         },
         {
             "name": "oneup/flysystem-bundle",
@@ -3017,6 +3262,113 @@
                 "templating"
             ],
             "time": "2016-10-05 18:57:41"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^4.8.21",
+                "squizlabs/php_codesniffer": "^2.5",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2016-10-24 13:23:32"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2016-02-18 20:53:00"
         }
     ],
     "packages-dev": [

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -356,6 +356,8 @@ class DefaultController extends BaseController
 
     /*
      * @param Query $select A Query instance
+     * @param string $sort The sort string
+     * @param string $order The sort order
      */
     protected function addQuerySort(Query $select, $sort = '', $order = '')
     {

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -24,14 +24,14 @@ class User
     /**
      * @var string
      *
-     * @ORM\Column(name="startIpAddress", type="string", length=255)
+     * @ORM\Column(name="startIpAddress", type="integer")
      */
     private $startIpAddress;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="endIpAddress", type="string", length=255)
+     * @ORM\Column(name="endIpAddress", type="integer")
      */
     private $endIpAddress;
 
@@ -62,7 +62,7 @@ class User
     /**
      * Set startIpAddress.
      *
-     * @param string $startIpAddress
+     * @param int $startIpAddress
      *
      * @return User
      */
@@ -76,7 +76,7 @@ class User
     /**
      * Get startIpAddress.
      *
-     * @return string
+     * @return int
      */
     public function getStartIpAddress()
     {
@@ -86,7 +86,7 @@ class User
     /**
      * Set endIpAddress.
      *
-     * @param string $endIpAddress
+     * @param int $endIpAddress
      *
      * @return User
      */
@@ -100,7 +100,7 @@ class User
     /**
      * Get endIpAddress.
      *
-     * @return string
+     * @return int
      */
     public function getEndIpAddress()
     {

--- a/src/AppBundle/Repository/UserRepository.php
+++ b/src/AppBundle/Repository/UserRepository.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Tools\SchemaTool;
 
 /**
  * UserRepository.
@@ -12,11 +13,94 @@ use Doctrine\ORM\EntityRepository;
  */
 class UserRepository extends EntityRepository
 {
+    /*
+     * Compares client IP against Database-IPs to provide access
+     *
+     * @param string $clientIp The client IP
+     */
     public function compareIp($clientIp)
     {
         return $this->getEntityManager()
-                    ->createQuery('SELECT u.id FROM AppBundle:User u WHERE (:clientIp BETWEEN u.startIpAddress AND u.endIpAddress)')
+                    ->createQuery('SELECT u FROM AppBundle:User u WHERE (:clientIp BETWEEN u.startIpAddress AND u.endIpAddress)')
                     ->setParameter('clientIp', $clientIp)
                     ->getResult();
+    }
+
+    /*
+     * Creates database table by the given entity
+     *
+     * @param string $entityName The entity name
+     * @param string $suffix The table name suffix
+     */
+    public function createTableByEntity($entityName, $suffix = null)
+    {
+        $schemaTool = new SchemaTool($this->getEntityManager());
+        $metadata = $this->getEntityManager()->getClassMetadata($entityName);
+
+        if ($suffix !== null) {
+            $tableName = $metadata->getTableName().$suffix;
+        } else {
+            $tableName = $metadata->getTableName();
+        }
+
+        $metadata->setPrimaryTable(['name' => $tableName]);
+        $schemaTool->createSchema([$metadata]);
+    }
+
+    /*
+     * Checks if a given table exists
+     *
+     * @param string The table name
+     *
+     * @return boolean
+     */
+    public function checkIfTableExists($tableName)
+    {
+        $schemaManager = $this->getEntityManager()->getConnection()->getSchemaManager();
+        if ($schemaManager->tablesExist(array($tableName)) === true) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /*
+     * Stores a IP data row in the database
+     *
+     * @param integer $startIpAddress The start of an IP range
+     * @param integer $endIpAddress The end of an IP range
+     * @param string $institution The institution name
+     * @param string $product The product name
+     */
+    public function storeTempDataRow($userTempTable, $startIpAddress, $endIpAddress, $institution, $product)
+    {
+        $sql = 'INSERT INTO '.$userTempTable.' ("startIpAddress", "endIpAddress", "institution", "product") VALUES (:startIpAddress, :endIpAddress, :institution, :product)';
+        $stmt = $this->getEntityManager()->getConnection()->prepare($sql);
+        $stmt->bindValue('startIpAddress', $startIpAddress);
+        $stmt->bindValue('endIpAddress', $endIpAddress);
+        $stmt->bindValue('institution', $institution);
+        $stmt->bindValue('product', $product);
+        $stmt->execute();
+    }
+
+    /*
+     * Drops the original user table
+     *
+     * @param $userTable The user table name
+     */
+    public function dropUserTable($userTable)
+    {
+        $this->getEntityManager()->getConnection()->getSchemaManager()->dropTable($userTable);
+    }
+
+    /*
+     * Renames the user temp table to user table
+     *
+     * @param $userTable The user table name
+     * @param $userTempTable The user temp name
+     */
+    public function renameUserTempTable($userTable, $userTempTable)
+    {
+        $this->getEntityManager()->getConnection()->getSchemaManager()->renameTable($userTempTable, $userTable);
     }
 }


### PR DESCRIPTION
This creates a temp ip table and stores the imported ips therein.
Afterward the original ip table will be droped and the temp table
renamed.
Composer install is necessary and afterwards ```bin/console doctrine:migrations:migrate```

Resolves: NLHOS-141